### PR TITLE
Add support for linking to sections of the reference docs

### DIFF
--- a/source/_script.haml
+++ b/source/_script.haml
@@ -10,12 +10,25 @@
 
 :javascript
   $(function(){
-    $('a[href^=#]').click(function(){
-      var href= $(this).attr("href"),
-          target = $('.column-content a[href^=' + href + ']'), position;
-      if (!target) { return false; }
+    var scrollTarget = function(href){
+      var target = $('.column-content a[href^=' + href + ']'),
+        position;
+
+      if (!target || !target.length){
+        return;
+      }
+
       position = target.offset().top - 60;
-      $("html, body").animate({scrollTop:position}, 350, "swing");
-      return false;
+      $('body').animate({
+        scrollTop: position
+      }, 350, 'swing');
+    }
+
+    $('a[href^=#]').click(function(){
+      scrollTarget($(this).attr('href'));
     });
+
+    $(window).on('hashchange', function(){
+      scrollTarget(window.location.hash);
+    }).trigger('hashchange');
   });


### PR DESCRIPTION
Currently clicking on a link in the reference sidebar will scroll you to the correct section of the docs. This PR keeps that functionality the same but adds support for linking directly to any section of the docs.

This is done by updating the url hash when a link is clicked with the name of that item (i.e. http://c3js.org/reference.html#bindto). There is an event listener on hash change which will then scroll to the correct section. This hash change event also gets triggered on page load, so if there's a hash in the url the page will automatically scroll to that section.